### PR TITLE
fix: return correct processed image filenames in filter and noise end…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ __pycache__/
 *$py.class
 
 # Virtual environment
-venv/
+new/
 .env
 *.env
 

--- a/app/routes/filters.py
+++ b/app/routes/filters.py
@@ -87,7 +87,8 @@ class ApplyFilter(Resource):
             else:
                 return {"error": "Invalid filter type"}, 400
 
-            processed_image_path = save_processed_image(filtered)
+            # Save the filtered image with a unique filename
+            processed_image_filename = save_processed_image(filtered)
 
             # Get the original filename from the request
             original_filename = request.files['file'].filename
@@ -105,7 +106,7 @@ class ApplyFilter(Resource):
 
             return {
                 "message": f"{filter_type} filter applied successfully",
-                "processed_image": original_filename
+                "processed_image": processed_image_filename  # Return the new filename
             }
 
         except Exception as e:


### PR DESCRIPTION
…points

- Fix filters/apply endpoint to return processed_image_filename instead of original_filename
- Fix noise/add endpoint to return processed_image_filename instead of original_filename
- Remove debug logging statements from noise endpoint
- Ensure unique filenames for processed images to prevent overwrites
- Fix issue where processed images weren't appearing on screen due to incorrect filename references

This fixes the UI issue where filtered/noisy images weren't displaying properly because the endpoints were returning the original image filename instead of the processed image filename.